### PR TITLE
Readonly

### DIFF
--- a/lib/workflowmgr/workflowengine.rb
+++ b/lib/workflowmgr/workflowengine.rb
@@ -84,6 +84,17 @@ module WorkflowMgr
 
     end  # initialize
 
+    ##########################################
+    #
+    # rewind!
+    #
+    ##########################################
+    def disallow_readonly
+      if @dbServer.readonly?
+        WorkflowMgr.stderr('ERROR: cannot run this command on a read-only workflow.  Check database permissions and ownership.')
+        Process.exit(1)
+      end
+    end
 
     ##########################################
     #
@@ -91,6 +102,8 @@ module WorkflowMgr
     #
     ##########################################
     def rewind!
+      disallow_readonly
+
       with_locked_db {
         # Get task name and cycle time:
         rewind_task_name=@options.tasks.first
@@ -225,6 +238,8 @@ module WorkflowMgr
     #
     ##########################################
     def run
+      disallow_readonly
+
       with_locked_db {
 
         # Build the workflow objects from the contents of the workflow document
@@ -283,6 +298,8 @@ module WorkflowMgr
     #
     ##########################################
     def boot
+
+      disallow_readonly
 
       with_locked_db {
 
@@ -496,6 +513,8 @@ module WorkflowMgr
     #
     ##########################################
     def vacuum!(seconds)
+
+      disallow_readonly
 
       with_locked_db {
 

--- a/lib/workflowmgr/workflowengine.rb
+++ b/lib/workflowmgr/workflowengine.rb
@@ -86,7 +86,7 @@ module WorkflowMgr
 
     ##########################################
     #
-    # rewind!
+    # disallow_readonly
     #
     ##########################################
     def disallow_readonly


### PR DESCRIPTION
Resolves issue #6 by adding read-only detection to the `workflowdb`.  This allows `rocotostat` and `rocotocheck` to function properly on read-only databases.  Commands that require write access, such as `rocotorun`, will give error messages that users find more intuitive.  

Also, this change incorporates the fix for issue #4 because that critical bug fix was required during the test process.