### PR TITLE
Fix bug with SLURM if scontrol gives unexpected results

### DIFF
--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -285,7 +285,7 @@ private
   	record={}
 
   	# Look at all the attributes for this job and build the record
-	jobfields=Hash[job.split.collect {|f| f.split("=") }]
+        jobfields=Hash[job.split.collect {|f| f.split("=")}.collect{|f| f.length == 2 ? f : [f[0], '']}]
 
         # Skip records for other users
         next unless jobfields["UserId"] =~/^#{username}\(/

--- a/lib/workflowmgr/workflowdoc.rb
+++ b/lib/workflowmgr/workflowdoc.rb
@@ -26,6 +26,7 @@ module WorkflowMgr
     require 'workflowmgr/pbsprobatchsystem'
     require 'workflowmgr/lsfbatchsystem'    
     require 'workflowmgr/lsfcraybatchsystem'    
+    require 'workflowmgr/slurmbatchsystem'
     require 'workflowmgr/task'
 
     @@messages={


### PR DESCRIPTION
In trying to get rocoto working on the University of Maryland supercomputer (which uses SLURM), I found that the scripts were breaking because "scontrol show job" was giving unparsable output. In particular, some of the unused key/value pairs had no value, e.g the last line of the output from "scontrol show job" for us shows "Power=", which the ruby script couldn't handle. I've modified so that keys without a value are handled.

This should address the issues Steve Penny had when trying to get it working on UMD's computer.