### PR TITLE
Remove extraneous colon from cyclestring.rb that

### DIFF
--- a/lib/workflowmgr/cyclestring.rb
+++ b/lib/workflowmgr/cyclestring.rb
@@ -76,7 +76,7 @@ module WorkflowMgr
     #####################################################
     def inspect
 
-      if @offset:
+      if @offset
           return "<cyclestr offset=\"#{@offset}\">#{@str}</cyclestr>"
       else
           return "<cyclestr>#{@str}</cyclestr>"


### PR DESCRIPTION
was causing a syntax error.