### PR TITLE
Fix weird UTF-8 encoding problem for SLURM.  For some reason,

### DIFF
--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -278,6 +278,9 @@ private
         raise WorkflowMgr::SchedulerDown
       end
 
+      # Make sure queued_jobs is properly encoded
+      queued_jobs = queued_jobs.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+
       # For each job, find the various attributes and create a job record
       queued_jobs.split("\n").each { |job|
 


### PR DESCRIPTION
the output of scontrol had invalid UTF-8 characters in it.