### PR TITLE
Give a warning message if any tags are empty in Torque or MOAB/Torque…

### DIFF
--- a/lib/workflowmgr/torquebatchsystem.rb
+++ b/lib/workflowmgr/torquebatchsystem.rb
@@ -111,6 +111,11 @@ module WorkflowMgr
 
       # Add Torque batch system options translated from the generic options specification
       task.attributes.each do |option,value|
+         if value.is_a?(String)
+           if value.empty? and option != 'memory'
+             WorkflowMgr.stderr("DEPRECATION WARNING: <#{option}> has empty content.  This may be rejected by later versions of Rocoto.", 1)
+           end
+        end
         case option
           when :account
             input += "#PBS -A #{value}\n"

--- a/lib/workflowmgr/torquebatchsystem.rb
+++ b/lib/workflowmgr/torquebatchsystem.rb
@@ -111,10 +111,13 @@ module WorkflowMgr
 
       # Add Torque batch system options translated from the generic options specification
       task.attributes.each do |option,value|
-         if value.is_a?(String)
-           if value.empty? and option != 'memory'
+        if value.is_a?(String) && value.empty?
+          if option.to_s != 'memory'
+            WorkflowMgr.stderr("ERROR: <#{option}> has empty content.  Will discard this tag.",1)
+            next
+          else
              WorkflowMgr.stderr("DEPRECATION WARNING: <#{option}> has empty content.  This may be rejected by later versions of Rocoto.", 1)
-           end
+          end
         end
         case option
           when :account


### PR DESCRIPTION
Deprecation warning is given when any empty tags are found in a Torque or MOABTorque job except for the memory tag.  The warning states that support for empty tags may be removed in a later release.  