### PR TITLE
Fix bug in heterogeneous job workaround for old versions of Slurm.

### DIFF
--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -219,7 +219,7 @@ module WorkflowMgr
               }
 
               # Request total number of nodes
-              node_input += "#SBATCH --nodes=#{nnodes}-#{nnodes}\n"
+              node_input = "#SBATCH --nodes=#{nnodes}-#{nnodes}\n"
 
               # Request max tasks per node
               node_input += "#SBATCH --tasks-per-node=#{maxppn}\n"


### PR DESCRIPTION
A string was being appended to before it was initialized.