### PR TITLE
Bugfix/surm no default export

### DIFF
--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -288,7 +288,7 @@ module WorkflowMgr
       end
 
       # Do not export variables by default
-      varinput+="--export=NONE\n"
+      input+="--export=NONE\n"
 
       # Add export commands to pass environment vars to the job
       unless task.envars.empty?

--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -287,6 +287,9 @@ module WorkflowMgr
         input += this_group_nodes
       end
 
+      # Do not export variables by default
+      varinput+="--export=NONE\n"
+
       # Add export commands to pass environment vars to the job
       unless task.envars.empty?
         varinput=''


### PR DESCRIPTION
Fixes issue #39.  In SLURM, by default, all environment variables are exported to the job, leading to a variety of confusing errors. This change disables exporting of variables so that only the ones in `<envar>` blocks are exported.