### PR TITLE
Fix a syntax error in the generated sbatch cards from slurmbatchsystem.rb

### DIFF
--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -296,7 +296,7 @@ module WorkflowMgr
       end
 
       # Do not export variables by default
-      input+="--export=NONE\n"
+      input+="#SBATCH --export=NONE\n"
 
       # Add export commands to pass environment vars to the job
       unless task.envars.empty?


### PR DESCRIPTION
This is an emergency commit; anything other than shell will abort with a syntax error.