### PR TITLE
Calls to sacct are not cached, resulting in many calls.

### DIFF
--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -462,6 +462,8 @@ private
     #####################################################
     def refresh_jobacct(delta_days)
 
+      @jobacct_duration=delta_days
+
       begin
 
         # Get the username of this process


### PR DESCRIPTION
Calls to sacct are not cached between calls to `status()`, resulting in sacct being called for every job that requires sacct's output.