### PR TITLE
This reverts the pull request that causes environment variables NOT to

### DIFF
--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -295,9 +295,6 @@ module WorkflowMgr
         input += this_group_nodes
       end
 
-      # Do not export variables by default
-      input+="#SBATCH --export=NONE\n"
-
       # Add export commands to pass environment vars to the job
       unless task.envars.empty?
         varinput=''


### PR DESCRIPTION
be exported by default.  The problem is that the setting is inherited
by subsequent srun commands in the job script.  That, in turn, causes
the environment created by module commands in job scripts not to be
propagated to the execution environment of binaries. This is unintuitive
and undesirable behavior that causes huge usability problems.