### PR TITLE
Fix XML validation problems associated with <nodes> and <cores>.

### DIFF
--- a/lib/workflowmgr/pbsprobatchsystem.rb
+++ b/lib/workflowmgr/pbsprobatchsystem.rb
@@ -231,7 +231,8 @@ module WorkflowMgr
                  ompthreads=$1.to_i
                end
                input += chunk.gsub(/ppn=\d+/,"mpiprocs=#{mpiprocs}").gsub(/tpp=\d+/,"ompthreads=#{ompthreads}")
-               input += ":ncpus=#{nodesize}"
+#               input += ":ncpus=#{nodesize}"
+               input += ":ncpus=#{mpiprocs * ompthreads}"
                input += ":mem=#{task.attributes[:memory]}" unless task.attributes[:memory].nil?
                input += "+"
              }

--- a/lib/workflowmgr/schema_with_metatasks.rng
+++ b/lib/workflowmgr/schema_with_metatasks.rng
@@ -465,31 +465,22 @@
           </element>
         </optional>
 
-        <!-- Either one cores tag or one nodes or at least one native tag is required-->
+        <!-- Either one cores tag or one nodes tag is required-->
         <choice>
-          <interleave>
-	    <choice>
-	      <element name="cores">
-		<data type="positiveInteger"/>
-	      </element>
-	      <element name="nodes">
-		<data type="string"/>
-	      </element>
-	    </choice>
-	    <optional>
-              <oneOrMore>
-	        <element name="native">
-		  <ref name="compoundTimeString"/>
-	        </element>
-              </oneOrMore>
-	    </optional>
-          </interleave>
-          <oneOrMore>
-            <element name="native">
-              <ref name="compoundTimeString"/>
-            </element>
-          </oneOrMore>
-        </choice>
+	    <element name="cores">
+	      <data type="positiveInteger"/>
+	    </element>
+	    <element name="nodes">
+	      <data type="string"/>
+	    </element>
+	</choice>
+
+        <!-- Zero or more native tags -->
+	<zeroOrMore>
+	  <element name="native">
+	    <ref name="compoundTimeString"/>
+	  </element>
+	</zeroOrMore>
 
         <!-- One walltime tag -->
         <element name="walltime">

--- a/lib/workflowmgr/schema_without_metatasks.rng
+++ b/lib/workflowmgr/schema_without_metatasks.rng
@@ -446,31 +446,22 @@
           </element>
         </optional>
 
-        <!-- Either one cores tag or one nodes or at least one native tag is required-->
+        <!-- Either one cores tag or one nodes tag is required-->
         <choice>
-          <interleave>
-	    <choice>
-	      <element name="cores">
-		<data type="positiveInteger"/>
-	      </element>
-	      <element name="nodes">
-		<data type="string"/>
-	      </element>
-	    </choice>
-	    <optional>
-              <oneOrMore>
-	        <element name="native">
-		  <ref name="compoundTimeString"/>
-	        </element>
-              </oneOrMore>
-	    </optional>
-          </interleave>
-          <oneOrMore>
-            <element name="native">
-              <ref name="compoundTimeString"/>
-            </element>
-          </oneOrMore>
-        </choice>
+	    <element name="cores">
+	      <data type="positiveInteger"/>
+	    </element>
+	    <element name="nodes">
+	      <data type="string"/>
+	    </element>
+	</choice>
+
+        <!-- Zero or more native tags -->
+	<zeroOrMore>
+	  <element name="native">
+	    <ref name="compoundTimeString"/>
+	  </element>
+	</zeroOrMore>
 
         <!-- One walltime tag -->
         <element name="walltime">


### PR DESCRIPTION
The previous idea of allowing <native> to be used for customized
resource requests was flawed.
Fix computation of ncpus for pbspro batch system.  Consumable
resources can be specified as is; no need for <native>.