### PR TITLE
Slurm <exclusive> support

### DIFF
--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -21,6 +21,15 @@ module WorkflowMgr
     require 'securerandom'
     require 'workflowmgr/utilities'
 
+    @@features = {
+      :shared => true,
+      :exclusive => true
+    }
+
+    def self.feature?(flag)
+      return !!@@features[flag]
+    end
+
     #####################################################
     #
     # initialize
@@ -152,6 +161,10 @@ module WorkflowMgr
            end
         end
         case option
+          when :exclusive
+            if task.attributes[:shared].nil? or not task.attributes[:shared]
+              input += "#SBATCH --exclusive\n"
+            end
           when :account
             input += "#SBATCH --account=#{value}\n"
           when :queue


### PR DESCRIPTION
When `<exclusive/>` is used with slurm, pass the `--exclusive` option. The `<shared/>` option is ignored since there is, as far as I can tell, no way to explicitly request a shared job. This behavior is consistent with lsfcraybatchsystem.rb