### PR TITLE
Increase DRb timeouts to improve recovery during heavy loads.

### DIFF
--- a/lib/workflowmgr/bqsproxy.rb
+++ b/lib/workflowmgr/bqsproxy.rb
@@ -58,7 +58,7 @@ module WorkflowMgr
           define_method m do |*args|
             retries=0
             begin
-              WorkflowMgr.timeout(90) do
+              WorkflowMgr.timeout(150) do
                 @bqServer.send(m,*args)
               end
             rescue DRb::DRbConnError

--- a/lib/workflowmgr/dbproxy.rb
+++ b/lib/workflowmgr/dbproxy.rb
@@ -56,7 +56,7 @@ module WorkflowMgr
             retries=0
             busy_retries=0.0
             begin
-              WorkflowMgr.timeout(45) do
+              WorkflowMgr.timeout(150) do
                 @dbServer.send(m,*args)
               end
             rescue DRb::DRbConnError

--- a/lib/workflowmgr/workflowioproxy.rb
+++ b/lib/workflowmgr/workflowioproxy.rb
@@ -107,7 +107,7 @@ module WorkflowMgr
 
             retries=0
             begin
-              WorkflowMgr.timeout(45) do
+              WorkflowMgr.timeout(150) do
                 @workflowIOServer.send(m,*args)
               end
             rescue DRb::DRbConnError

--- a/lib/workflowmgr/workflowserver.rb
+++ b/lib/workflowmgr/workflowserver.rb
@@ -91,7 +91,7 @@ module WorkflowMgr
       raise "Server is not initialized, must call WorkflowServer.setup to initialize it." unless @setup
 
       begin
-        WorkflowMgr.timeout(40) do
+        WorkflowMgr.timeout(150) do
           return @server.send(name,*args,&block)
         end
       rescue Timeout::Error


### PR DESCRIPTION
May sometimes result in longer intervals between successful
completion of rocotorun commands, but improves overall resiliency
by allowing slow operations to complete instead of producing
persistent timeouts and failure.