### PR TITLE
Fix sqlite3 library path in install script

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -231,7 +231,7 @@ cd ${BUILD_DIR}
 gunzip -c ${TAR_DIR}/sqlite3-ruby-${SQLITE3_RUBY_VERSION}.tar.gz | tar -xvf -
 cd sqlite3-ruby-${SQLITE3_RUBY_VERSION}/ext/sqlite3
 export LD_RUN_PATH=${LIB_DIR}/sqlite3/lib
-${RUBY} extconf.rb -- --with-sqlite3-dir=${LIB_DIR}/sqlite3
+${RUBY} extconf.rb -- --with-sqlite3-dir=${LIB_DIR}/sqlite3 --with-sqlite3-lib=${LIB_DIR}/sqlite3/lib
 make clean
 make
 rm -rf ${LIB_DIR}/sqlite3-ruby


### PR DESCRIPTION
I'm going to preface this by saying my ruby experience is limited to hacking round with it for the last couple hours. So I have no idea what causes this. (Maybe an old-ish version of Ruby?)

In trying to install, I ran into an issue where sqlite3-ruby couldn't find the sqlite3 libraries that the install script just created. This is because it was looking in the the root of the install directory instead of the lib subdirectory. In looking around, I figured out that I could add this --with-sqlite3-lib argument, and it pointed sqlite3-ruby to the right place.