### PR TITLE
fix typo: core_signal => code_signal

### DIFF
--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -477,7 +477,7 @@ private
         code_signal=job[230..239].strip
         if code_signal=~ /:/
 
-          code,signal=core_signal.split(":").collect {|i| i.to_i}
+          code,signal=code_signal.split(":").collect {|i| i.to_i}
           if code==0
             record[:exit_status]=signal
           else


### PR DESCRIPTION
Fixes #96 wherein a typo in slurmbatchsystem.rb breaks support for `0:0` style return codes.

```ruby
  code_signal=job[230..239].strip
  if code_signal=~ /:/
    code,signal=core_signal.split(":").collect {|i| i.to_i}
```

The last line has `core_signal` but the variable's name is `code_signal`.

This is a draft because I'm waiting for @natalie-perlin to test it. Once she confirms, we'll know it fixes #96