### PR TITLE
Ruby 3.2.2 support: File.exists() no longer exists

### DIFF
--- a/lib/workflowmgr/cobaltbatchsystem.rb
+++ b/lib/workflowmgr/cobaltbatchsystem.rb
@@ -310,7 +310,7 @@ private
       begin
 
         joblogfile = "#{ENV['HOME']}/.rocoto/#{WorkflowMgr.version}/tmp/#{jobid}.log"
-        return unless  File.exists?(joblogfile)
+        return unless  File.exist?(joblogfile)
         joblog = IO.readlines(joblogfile,nil)[0]
 
         # Return if the joblog output is empty

--- a/lib/workflowmgr/dependency.rb
+++ b/lib/workflowmgr/dependency.rb
@@ -953,7 +953,7 @@ module WorkflowMgr
     def resolved?(d)
 
       filename=@datapath.to_s(d.cycle)
-      if d.workflowIOServer.exists?(filename)
+      if d.workflowIOServer.exist?(filename)
         if d.workflowIOServer.size(filename) >= @minsize
           return Time.now > (d.workflowIOServer.mtime(filename) + @age)
         else
@@ -973,7 +973,7 @@ module WorkflowMgr
     def query(d)
 
       filename=@datapath.to_s(d.cycle)
-      if d.workflowIOServer.exists?(filename)
+      if d.workflowIOServer.exist?(filename)
         if Time.now > (d.workflowIOServer.mtime(filename) + @age)
           if d.workflowIOServer.size(filename) >= @minsize
             return [{:dep=>filename, :msg=>"is available", :resolved=>true }]

--- a/lib/workflowmgr/nobatchsystem.rb
+++ b/lib/workflowmgr/nobatchsystem.rb
@@ -583,7 +583,7 @@ class NoBatchSystem
       fname="#{@acct_path}/accounting.#{date_str}"
 
       # If the file already exists roll it over
-      if File.exists?(fname)
+      if File.exist?(fname)
 
         # Find all files associated with that date sorted by modification date
         oldfiles=files.find_all { |file|

--- a/lib/workflowmgr/utilities.rb
+++ b/lib/workflowmgr/utilities.rb
@@ -202,7 +202,7 @@ module WorkflowMgr
         begin
 
           # Only rotate logs if they exist
-          if File.exists?(rocotolog)
+          if File.exist?(rocotolog)
 
             # Determine if it is time to rotate the logs
             log_mod_time = File.mtime(rocotolog)
@@ -226,7 +226,7 @@ module WorkflowMgr
 
             end  # if rotate?
 
-          end  # if File.exists?
+          end  # if File.exist?
 
           # Log the message
           File.open(rocotolog,"a") { |f|

--- a/lib/workflowmgr/workflowconfig.rb
+++ b/lib/workflowmgr/workflowconfig.rb
@@ -49,19 +49,19 @@ module WorkflowMgr
       begin
 
         # Create a .rocoto directory if one does not already exist
-        FileUtils.mkdir_p(@config_dir) unless File.exists?(@config_dir)
+        FileUtils.mkdir_p(@config_dir) unless File.exist?(@config_dir)
 
         # Create a .rocoto log directory for this workflow if one does not already exist
-        FileUtils.mkdir_p(@config_log) unless File.exists?(@config_log)
+        FileUtils.mkdir_p(@config_log) unless File.exist?(@config_log)
 
         # Create a .rocoto tmp dir if one does not already exist
-        FileUtils.mkdir_p(@config_tmp) unless File.exists?(@config_tmp)
+        FileUtils.mkdir_p(@config_tmp) unless File.exist?(@config_tmp)
 
         # Move the legacy .wfmrc file to rocotorc file if it exists
-        FileUtils.mv("#{ENV['HOME']}/.wfmrc",@config_file) if File.exists?("#{ENV['HOME']}/.wfmrc")
+        FileUtils.mv("#{ENV['HOME']}/.wfmrc",@config_file) if File.exist?("#{ENV['HOME']}/.wfmrc")
 
         # Load the rocotorc config if one exists
-        if File.exists?(@config_file) && !File.zero?(@config_file)
+        if File.exist?(@config_file) && !File.zero?(@config_file)
           config=YAML.load_file(@config_file)
           if config.is_a?(Hash)
             # Merge default config into rocotorc config if there are unspecified config options
@@ -88,7 +88,7 @@ module WorkflowMgr
         raise msg
       ensure
         # Update the config file in a quasi-atomic way.
-        FileUtils.mv("#{@config_file}.#{Process.pid}", @config_file) if File.exists?("#{@config_file}.#{Process.pid}")
+        FileUtils.mv("#{@config_file}.#{Process.pid}", @config_file) if File.exist?("#{@config_file}.#{Process.pid}")
       end
 
     end  # initialize

--- a/lib/workflowmgr/workflowdb.rb
+++ b/lib/workflowmgr/workflowdb.rb
@@ -1019,7 +1019,7 @@ module WorkflowMgr
       if @mode[:readonly]
 
         # Make sure the database file exists and that we can read it
-        if File.exists?(@database_file)
+        if File.exist?(@database_file)
           if !File.readable?(@database_file)
             raise WorkflowDBAccessException, "ERROR: You do not have permission to read #{@database_file}"
           end
@@ -1035,7 +1035,7 @@ module WorkflowMgr
 
         # Make sure the database and database lock files are writable
         [@database_file, @database_lock_file].each do |dbfile|
-          if File.exists?(dbfile)
+          if File.exist?(dbfile)
             if !File.writable?(dbfile)
               raise WorkflowDBAccessException, "ERROR: You do not have permission to modify #{dbfile}"
             end

--- a/lib/workflowmgr/workflowdoc.rb
+++ b/lib/workflowmgr/workflowdoc.rb
@@ -75,7 +75,7 @@ module WorkflowMgr
       # external entities on other filesystems) outside the IO server
       # process.
       begin
-        if @workflowIOServer.exists?(workflowdoc)
+        if @workflowIOServer.exist?(workflowdoc)
           context = LibXML::XML::Parser::Context.file(workflowdoc)
           context.options=LibXML::XML::Parser::Options::NOENT | LibXML::XML::Parser::Options::HUGE | LibXML::XML::Parser::Options::NOCDATA
           parser=LibXML::XML::Parser.new(context)

--- a/lib/workflowmgr/workflowio.rb
+++ b/lib/workflowmgr/workflowio.rb
@@ -56,9 +56,9 @@ module WorkflowMgr
     # exists?
     #
     ##########################################
-    def exists?(filename)
+    def exist?(filename)
 
-      return File.exists?(filename)
+      return File.exist?(filename)
 
     end
 
@@ -152,7 +152,7 @@ module WorkflowMgr
     def roll_log(logname)
 
       # If the log file exists, roll it
-      if File.exists?(logname)
+      if File.exist?(logname)
 
         Dir["#{logname}*"].sort.reverse.each do |f|
           if f=~/#{logname}\.(\d+)$/ then

--- a/test/test_forkit.rb
+++ b/test/test_forkit.rb
@@ -16,9 +16,9 @@ puts result.inspect
 
 exit
 
-# File exists?
+# File exist?
 result=forkit(2) do
-  File.exists?(filename)
+  File.exist?(filename)
 end
 puts result
 
@@ -33,6 +33,6 @@ end
 # Performance test of forking
 10.times do
   result=forkit(1) do
-    File.exists?(filename)
+    File.exist?(filename)
   end
 end


### PR DESCRIPTION
Ruby 3.2.2 removed the deprecated `File.exists?`. This PR changes all of them to the non-deprecated `File.exist?`. For consistency, I also renamed WorkflowIOServer.exists?

Edit: This is necessary to support the Hercules cluster because its only complete Ruby installation is 3.2.2.