### PR TITLE
Include options for non-standard libxml2 installation locations

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -12,10 +12,18 @@ GEM_DIR=${WFM_DIR}/gems
 for arg in $@; do
   case $arg in
     --with-ruby=*) RUBY=$(echo $arg | cut -f 2 -d "=")/bin/ruby;;
+    --with-xml2-dir=*) xml2dir=$(echo $arg | cut -f 2 -d "=");;
+    --with-xml2-include=*) xml2include=$(echo $arg | cut -f 2 -d "=");;
+    --with-xml2-config=*) xml2config=$(echo $arg | cut -f 2 -d "=");;
+    --with-xml2-lib=*) xml2lib=$(echo $arg | cut -f 2 -d "=");;
     -h|--help) echo
                echo "Run this script to install the Workflow Manager"
                echo
-               echo "INSTALL [--with-ruby=/path/to/ruby]"
+               echo 'INSTALL [--with-ruby=/path/to/ruby]'
+               echo '[--with-xml2-dir=/path/to/${xml2-dir}]'
+               echo '[--with-xml2-include=/path/to/${xml2-dir}/include]'
+               echo '[--with-xml2-config=/path/to/xml2-config]'
+               echo '[--with-xml2-lib=/path/to/${xml2-dir}/lib]'
                echo
                exit;;
     *)
@@ -39,6 +47,27 @@ else
   exit 1
 fi
 
+GEM_ARGS=""
+# Check whether libxml2 headers, libs, and xml2-config are defined
+# xml2dir
+if [[  -n "$xml2dir" &&  -d "$xml2dir" ]]; then
+    GEM_ARGS+=" --with-xml2-dir="$xml2dir
+    [[ -z "${xml2include+x}" || ! -d "${xml2include}" ]] && xml2include=${xml2dir}/include
+    [[ -z "${xml2lib+x}" || ! -d "${xml2lib}" ]] && xml2lib=${xml2dir}/lib
+    [[ -z "${xml2config+x}" || ! -d "${xml2config}" ]] && xml2config=${xml2dir}/bin/xml2-config
+fi
+# Add configuration options if they are set:
+if [[ -n "${xml2include}" && -d "${xml2include}" ]]; then 
+   GEM_ARGS+=" --with-xml2-include="$xml2include
+fi
+
+if [[ -n "${xml2lib}" && -d "${xml2lib}" ]]; then 
+   GEM_ARGS+=" --with-xml2-lib="$xml2lib
+fi
+
+if [[ -n "${xml2config}" && -f "${xml2config}" ]]; then 
+   GEM_ARGS+=" --with-xml2-config="$xml2config
+fi
 # Abort if any command returns an error
 set -e
 
@@ -64,9 +93,11 @@ done
 
 # Install gem dependencies into local gem repository
 gem install -i ${GEM_DIR} --no-user-install --no-document \
-    libxml-ruby:5.0.3 \
     open4:1.3.4 \
     rubysl-date:1.0.1 \
     rubysl-parsedate:1.0.1 \
     sqlite3:1.7.3 \
-    thread:0.2.2
+    thread:0.2.2 \
+    libxml-ruby:5.0.3 \
+    -- $GEM_ARGS
+


### PR DESCRIPTION
Rocoto installation fails if libxml2 headers and/or libraries not found in standard locations.
Failure occurs when building libxml-ruby v5.0.3 using gem/ ruby package manager.

Added arguments 
--with-xml2-dir=/path/to/${xml2-dir}
--with-xml2-include=/path/to/${xml2-dir}/include
--with-xml2-config=/path/to/xml2-config
--with-xml2-lib=/path/to/${xml2-dir}/lib

to the INSTALL script, which are then parsed and passed as configuration options to gem installation.

This was needed, for example, on Derecho. Ruby > v3 was available, but libxml2 not installed. Libxml2 has been then built from the source code, and location of the libraries,headers & xml2-config passed as arguments to gem.

Example of a successful installation:

```
./INSTALL --with-xml2-dir=/glade/derecho/scratch/nperlin/libxml2 --with-xml2-lib=/glade/derecho/scratch/nperlin/libxml2/lib --with-xml2-include=/glade1/derecho/scratch/nperlin/libxml2/include --with-xml2-config=/glade/derecho/scratch/nperlin/libxml2/bin/xml2-config
```

(NB: the path `--with-xml2-include=` was intentionally set incorrectly in the command line. The installation script corrected the path to the existing directory with headers, given the `xml2-dir` variable was provided )

The log from the install was as follows:

```
Installing using /glade/u/apps/derecho/24.12/opt/view/bin/ruby
Fetching open4-1.3.4.gem
Successfully installed open4-1.3.4
Fetching rubysl-date-1.0.1.gem
Successfully installed rubysl-date-1.0.1
Fetching rubysl-parsedate-1.0.1.gem
Successfully installed rubysl-parsedate-1.0.1
Fetching sqlite3-1.7.3-x86_64-linux.gem
Successfully installed sqlite3-1.7.3-x86_64-linux
Fetching thread-0.2.2.gem
Successfully installed thread-0.2.2
Fetching libxml-ruby-5.0.3.gem
Building native extensions with: '--with-xml2-dir=/glade/derecho/scratch/nperlin/libxml2 --with-xml2-include=/glade/derecho/scratch/nperlin/libxml2/include --with-xml2-lib=/glade/derecho/scratch/nperlin/libxml2/lib --with-xml2-config=/glade/derecho/scratch/nperlin/libxml2/bin/xml2-config'
This could take a while...
Successfully installed libxml-ruby-5.0.3
6 gems installed

```