### PR TITLE
Allow `-n | --dryrun` for submission rocoto commands

### DIFF
--- a/lib/workflowmgr/cobaltbatchsystem.rb
+++ b/lib/workflowmgr/cobaltbatchsystem.rb
@@ -188,10 +188,16 @@ module WorkflowMgr
       WorkflowMgr.stderr("Submitting #{task.attributes[:name]} using #{cmd} --mode script #{tf.path} with input {{#{input}}}",4)
 
       # Run the submit command
-      output=`#{cmd} --mode script #{tf.path} 2>&1`.chomp()
+      if WorkflowMgr.DRYRUN
+        output="This is a dryrun"
+      else
+        output=`#{cmd} --mode script #{tf.path} 2>&1`.chomp()
+      end
 
       # Parse the output of the submit command
       if output=~/^(\d+)$/
+        return $1,output
+      elsif output=~/^This is a dryrun/
         return $1,output
       else
         return nil,output

--- a/lib/workflowmgr/cobaltbatchsystem.rb
+++ b/lib/workflowmgr/cobaltbatchsystem.rb
@@ -197,8 +197,6 @@ module WorkflowMgr
       # Parse the output of the submit command
       if output=~/^(\d+)$/
         return $1,output
-      elsif output=~/^This is a dryrun/
-        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/cobaltbatchsystem.rb
+++ b/lib/workflowmgr/cobaltbatchsystem.rb
@@ -188,7 +188,7 @@ module WorkflowMgr
       WorkflowMgr.stderr("Submitting #{task.attributes[:name]} using #{cmd} --mode script #{tf.path} with input {{#{input}}}",4)
 
       # Run the submit command
-      if WorkflowMgr.DRYRUN
+      if WorkflowMgr::DRYRUN > 0
         output="This is a dryrun"
       else
         output=`#{cmd} --mode script #{tf.path} 2>&1`.chomp()

--- a/lib/workflowmgr/cobaltbatchsystem.rb
+++ b/lib/workflowmgr/cobaltbatchsystem.rb
@@ -198,7 +198,7 @@ module WorkflowMgr
       if output=~/^(\d+)$/
         return $1,output
       elsif output=~/^This is a dryrun/
-        return $1,output
+        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/lsfbatchsystem.rb
+++ b/lib/workflowmgr/lsfbatchsystem.rb
@@ -318,13 +318,19 @@ module WorkflowMgr
       tf.flush()
 
       # Run the submit command script
-      output=`/bin/sh #{tf.path} 2>&1`.chomp
+      if WorkflowMgr.DRYRUN
+        output="This is a dryrun"
+      else
+        output=`/bin/sh #{tf.path} 2>&1`.chomp
+      end
 
       WorkflowMgr.log("Submitted #{task.attributes[:name]} using '/bin/sh #{tf.path} 2>&1' with input {{#{envstr + cmd}}}")
       WorkflowMgr.stderr("Submitted #{task.attributes[:name]} using '/bin/sh #{tf.path} 2>&1' with input {{#{envstr + cmd}}}",4)
 
       # Parse the output of the submit command
       if output=~/Job <(\d+)> is submitted to (default )*queue/
+        return $1,output
+      elsif output=~/^This is a dryrun/
         return $1,output
       else
         return nil,output

--- a/lib/workflowmgr/lsfbatchsystem.rb
+++ b/lib/workflowmgr/lsfbatchsystem.rb
@@ -318,7 +318,7 @@ module WorkflowMgr
       tf.flush()
 
       # Run the submit command script
-      if WorkflowMgr.DRYRUN
+      if WorkflowMgr::DRYRUN > 0
         output="This is a dryrun"
       else
         output=`/bin/sh #{tf.path} 2>&1`.chomp

--- a/lib/workflowmgr/lsfbatchsystem.rb
+++ b/lib/workflowmgr/lsfbatchsystem.rb
@@ -330,8 +330,6 @@ module WorkflowMgr
       # Parse the output of the submit command
       if output=~/Job <(\d+)> is submitted to (default )*queue/
         return $1,output
-      elsif output=~/^This is a dryrun/
-        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/lsfbatchsystem.rb
+++ b/lib/workflowmgr/lsfbatchsystem.rb
@@ -331,7 +331,7 @@ module WorkflowMgr
       if output=~/Job <(\d+)> is submitted to (default )*queue/
         return $1,output
       elsif output=~/^This is a dryrun/
-        return $1,output
+        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/lsfcraybatchsystem.rb
+++ b/lib/workflowmgr/lsfcraybatchsystem.rb
@@ -187,13 +187,19 @@ module WorkflowMgr
       tf.flush()
 
       # Run the submit command script
-      output=`/bin/sh #{tf.path} 2>&1`.chomp
+      if WorkflowMgr.DRYRUN
+        output="This is a dryrun"
+      else
+        output=`/bin/sh #{tf.path} 2>&1`.chomp
+      end
 
       WorkflowMgr.log("Submitted #{task.attributes[:name]} using '/bin/sh #{tf.path} 2>&1' with input {{#{envstr + cmd}}}")
       WorkflowMgr.stderr("Submitted #{task.attributes[:name]} using '/bin/sh #{tf.path} 2>&1' with input {{#{envstr + cmd}}}",4)
 
       # Parse the output of the submit command
       if output=~/Job <(\d+)> is submitted to (default )*queue/
+        return $1,output
+      elsif output=~/^This is a dryrun/
         return $1,output
       else
         return nil,output

--- a/lib/workflowmgr/lsfcraybatchsystem.rb
+++ b/lib/workflowmgr/lsfcraybatchsystem.rb
@@ -199,8 +199,6 @@ module WorkflowMgr
       # Parse the output of the submit command
       if output=~/Job <(\d+)> is submitted to (default )*queue/
         return $1,output
-      elsif output=~/^This is a dryrun/
-        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/lsfcraybatchsystem.rb
+++ b/lib/workflowmgr/lsfcraybatchsystem.rb
@@ -187,7 +187,7 @@ module WorkflowMgr
       tf.flush()
 
       # Run the submit command script
-      if WorkflowMgr.DRYRUN
+      if WorkflowMgr::DRYRUN > 0
         output="This is a dryrun"
       else
         output=`/bin/sh #{tf.path} 2>&1`.chomp

--- a/lib/workflowmgr/lsfcraybatchsystem.rb
+++ b/lib/workflowmgr/lsfcraybatchsystem.rb
@@ -200,7 +200,7 @@ module WorkflowMgr
       if output=~/Job <(\d+)> is submitted to (default )*queue/
         return $1,output
       elsif output=~/^This is a dryrun/
-        return $1,output
+        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/moabbatchsystem.rb
+++ b/lib/workflowmgr/moabbatchsystem.rb
@@ -195,10 +195,16 @@ module WorkflowMgr
       WorkflowMgr.stderr("Submitting #{task.attributes[:name]} using #{cmd} < #{tf.path} with input {{#{input}}}",4)
 
       # Run the submit command
-      output=`#{cmd} < #{tf.path} 2>&1`.chomp()
+      if WorkflowMgr.DRYRUN
+        output="This is a dryrun"
+      else
+        output=`#{cmd} < #{tf.path} 2>&1`.chomp()
+      end
 
       # Parse the output of the submit command
       if output=~/^((\w+\.)*\d+)$/
+        return $1,output
+      elsif output=~/^This is a dryrun/
         return $1,output
       else
         return nil,output

--- a/lib/workflowmgr/moabbatchsystem.rb
+++ b/lib/workflowmgr/moabbatchsystem.rb
@@ -204,8 +204,6 @@ module WorkflowMgr
       # Parse the output of the submit command
       if output=~/^((\w+\.)*\d+)$/
         return $1,output
-      elsif output=~/^This is a dryrun/
-        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/moabbatchsystem.rb
+++ b/lib/workflowmgr/moabbatchsystem.rb
@@ -205,7 +205,7 @@ module WorkflowMgr
       if output=~/^((\w+\.)*\d+)$/
         return $1,output
       elsif output=~/^This is a dryrun/
-        return $1,output
+        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/moabbatchsystem.rb
+++ b/lib/workflowmgr/moabbatchsystem.rb
@@ -195,7 +195,7 @@ module WorkflowMgr
       WorkflowMgr.stderr("Submitting #{task.attributes[:name]} using #{cmd} < #{tf.path} with input {{#{input}}}",4)
 
       # Run the submit command
-      if WorkflowMgr.DRYRUN
+      if WorkflowMgr::DRYRUN > 0
         output="This is a dryrun"
       else
         output=`#{cmd} < #{tf.path} 2>&1`.chomp()

--- a/lib/workflowmgr/pbsprobatchsystem.rb
+++ b/lib/workflowmgr/pbsprobatchsystem.rb
@@ -217,10 +217,16 @@ module WorkflowMgr
       WorkflowMgr.stderr("Submitting #{task.attributes[:name]} using #{cmd} < #{tf.path} with input {{#{input}}}",4)
 
       # Run the submit command
-      output=`#{cmd} < #{tf.path} 2>&1`.chomp()
+      if WorkflowMgr.DRYRUN
+        output="This is a dryrun"
+      else
+        output=`#{cmd} < #{tf.path} 2>&1`.chomp()
+      end
 
       # Parse the output of the submit command
       if output=~/^(\d+)(\.[a-zA-Z0-9-]+)*$/
+        return $1,output
+      elsif output=~/^This is a dryrun/
         return $1,output
       else
         return nil,output

--- a/lib/workflowmgr/pbsprobatchsystem.rb
+++ b/lib/workflowmgr/pbsprobatchsystem.rb
@@ -227,7 +227,7 @@ module WorkflowMgr
       if output=~/^(\d+)(\.[a-zA-Z0-9-]+)*$/
         return $1,output
       elsif output=~/^This is a dryrun/
-        return $1,output
+        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/pbsprobatchsystem.rb
+++ b/lib/workflowmgr/pbsprobatchsystem.rb
@@ -217,7 +217,7 @@ module WorkflowMgr
       WorkflowMgr.stderr("Submitting #{task.attributes[:name]} using #{cmd} < #{tf.path} with input {{#{input}}}",4)
 
       # Run the submit command
-      if WorkflowMgr.DRYRUN
+      if WorkflowMgr::DRYRUN > 0
         output="This is a dryrun"
       else
         output=`#{cmd} < #{tf.path} 2>&1`.chomp()

--- a/lib/workflowmgr/pbsprobatchsystem.rb
+++ b/lib/workflowmgr/pbsprobatchsystem.rb
@@ -226,8 +226,6 @@ module WorkflowMgr
       # Parse the output of the submit command
       if output=~/^(\d+)(\.[a-zA-Z0-9-]+)*$/
         return $1,output
-      elsif output=~/^This is a dryrun/
-        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/reportoption.rb
+++ b/lib/workflowmgr/reportoption.rb
@@ -17,6 +17,7 @@ module WorkflowMgr
     attr_reader :database
     attr_reader :workflowdoc
     attr_reader :verbose
+    attr_reader :dryrun
 
     ##########################################
     #
@@ -28,6 +29,7 @@ module WorkflowMgr
       @database=nil
       @workflowdoc=nil
       @verbose=0
+      @dryrun=false
       parse(args)
 
     end  # initialize
@@ -72,6 +74,12 @@ module WorkflowMgr
           WorkflowMgr.const_set("VERBOSE",@verbose)
         end
 
+        # Handle option for dryrun
+        opts.on("-n","--dryrun","Show Workflow Manager commands, but do not execute") do |dryrun|
+          @dryrun=true
+          WorkflowMgr.const_set("DRYRUN",@dryrun)
+        end
+
         # Handle option for version
         opts.on("--version","Show Workflow Manager version") do
           puts "Workflow Manager Version #{WorkflowMgr.version}"
@@ -93,6 +101,9 @@ module WorkflowMgr
 
           # Set verbose to 0 if not set by options
           WorkflowMgr.const_set("VERBOSE",0) unless WorkflowMgr.const_defined?("VERBOSE")
+
+          # Set dryrun to 0 if not set by options
+          WorkflowMgr.const_set("DRYRUN",false) unless WorkflowMgr.const_defined?("DRYRUN")
 
           # The -d and -w options are mandatory
           raise OptionParser::ParseError,"A database file must be specified" if @database.nil?

--- a/lib/workflowmgr/reportoption.rb
+++ b/lib/workflowmgr/reportoption.rb
@@ -29,7 +29,7 @@ module WorkflowMgr
       @database=nil
       @workflowdoc=nil
       @verbose=0
-      @dryrun=false
+      @dryrun=0
       parse(args)
 
     end  # initialize
@@ -76,7 +76,7 @@ module WorkflowMgr
 
         # Handle option for dryrun
         opts.on("-n","--dryrun","Show Workflow Manager commands, but do not execute") do |dryrun|
-          @dryrun=true
+          @dryrun=1
           WorkflowMgr.const_set("DRYRUN",@dryrun)
         end
 
@@ -103,7 +103,7 @@ module WorkflowMgr
           WorkflowMgr.const_set("VERBOSE",0) unless WorkflowMgr.const_defined?("VERBOSE")
 
           # Set dryrun to 0 if not set by options
-          WorkflowMgr.const_set("DRYRUN",false) unless WorkflowMgr.const_defined?("DRYRUN")
+          WorkflowMgr.const_set("DRYRUN",0) unless WorkflowMgr.const_defined?("DRYRUN")
 
           # The -d and -w options are mandatory
           raise OptionParser::ParseError,"A database file must be specified" if @database.nil?

--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -316,6 +316,7 @@ module WorkflowMgr
         output="This is a dryrun"
       else
         output=`#{cmd} < #{tf.path} 2>&1`.chomp()
+      end
 
       # Parse the output of the submit command
       if output=~/^Submitted batch job (\d+)/

--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -320,6 +320,8 @@ module WorkflowMgr
       # Parse the output of the submit command
       if output=~/^Submitted batch job (\d+)/
         return $1,output
+      elsif output=~/^This is a dryrun/
+        return $1,output
       elsif output=~/Batch job submission failed: Socket timed out/
 
         WorkflowMgr.stderr("WARNING: '#{output}', looking to see if job was submitted anyway...", 1)

--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -312,7 +312,10 @@ module WorkflowMgr
       WorkflowMgr.stderr("Submitting #{task.attributes[:name]} using #{cmd} < #{tf.path} with input\n{{\n#{input}\n}}", 4)
 
       # Run the submit command
-      output=`#{cmd} < #{tf.path} 2>&1`.chomp()
+      if WorkflowMgr.DRYRUN
+        output="This is a dryrun"
+      else
+        output=`#{cmd} < #{tf.path} 2>&1`.chomp()
 
       # Parse the output of the submit command
       if output=~/^Submitted batch job (\d+)/

--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -312,7 +312,7 @@ module WorkflowMgr
       WorkflowMgr.stderr("Submitting #{task.attributes[:name]} using #{cmd} < #{tf.path} with input\n{{\n#{input}\n}}", 4)
 
       # Run the submit command
-      if WorkflowMgr.DRYRUN
+      if WorkflowMgr::DRYRUN > 0
         output="This is a dryrun"
       else
         output=`#{cmd} < #{tf.path} 2>&1`.chomp()

--- a/lib/workflowmgr/slurmbatchsystem.rb
+++ b/lib/workflowmgr/slurmbatchsystem.rb
@@ -322,7 +322,7 @@ module WorkflowMgr
       if output=~/^Submitted batch job (\d+)/
         return $1,output
       elsif output=~/^This is a dryrun/
-        return $1,output
+        return nil,output
       elsif output=~/Batch job submission failed: Socket timed out/
 
         WorkflowMgr.stderr("WARNING: '#{output}', looking to see if job was submitted anyway...", 1)

--- a/lib/workflowmgr/torquebatchsystem.rb
+++ b/lib/workflowmgr/torquebatchsystem.rb
@@ -176,10 +176,16 @@ module WorkflowMgr
       WorkflowMgr.stderr("Submitting #{task.attributes[:name]} using #{cmd} < #{tf.path} with input {{#{input}}}",4)
 
       # Run the submit command
-      output=`#{cmd} < #{tf.path} 2>&1`.chomp()
+      if WorkflowMgr.DRYRUN
+        output="This is a dryrun"
+      else
+        output=`#{cmd} < #{tf.path} 2>&1`.chomp()
+      end
 
       # Parse the output of the submit command
       if output=~/^(\d+)(\.[a-zA-Z0-9-]+)*$/
+        return $1,output
+      elsif output=~/^This is a dryrun/
         return $1,output
       else
         return nil,output

--- a/lib/workflowmgr/torquebatchsystem.rb
+++ b/lib/workflowmgr/torquebatchsystem.rb
@@ -186,7 +186,7 @@ module WorkflowMgr
       if output=~/^(\d+)(\.[a-zA-Z0-9-]+)*$/
         return $1,output
       elsif output=~/^This is a dryrun/
-        return $1,output
+        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/torquebatchsystem.rb
+++ b/lib/workflowmgr/torquebatchsystem.rb
@@ -185,8 +185,6 @@ module WorkflowMgr
       # Parse the output of the submit command
       if output=~/^(\d+)(\.[a-zA-Z0-9-]+)*$/
         return $1,output
-      elsif output=~/^This is a dryrun/
-        return nil,output
       else
         return nil,output
       end

--- a/lib/workflowmgr/torquebatchsystem.rb
+++ b/lib/workflowmgr/torquebatchsystem.rb
@@ -176,7 +176,7 @@ module WorkflowMgr
       WorkflowMgr.stderr("Submitting #{task.attributes[:name]} using #{cmd} < #{tf.path} with input {{#{input}}}",4)
 
       # Run the submit command
-      if WorkflowMgr.DRYRUN
+      if WorkflowMgr::DRYRUN > 0
         output="This is a dryrun"
       else
         output=`#{cmd} < #{tf.path} 2>&1`.chomp()

--- a/lib/workflowmgr/workflowengine.rb
+++ b/lib/workflowmgr/workflowengine.rb
@@ -1924,7 +1924,11 @@ module WorkflowMgr
           if jobid.nil?
             # Delete the job from the database since it failed to submit.  It will be retried next time around.
             @dbServer.delete_jobs([job])
-            msg="Submission of #{job.task} failed!  #{output}"
+            if WorkflowMgr::DRYRUN > 0
+              msg="#{job.task} was not submitted!  #{output}"
+            else
+              msg="Submission of #{job.task} failed!  #{output}"
+            end
             @logServer.log(job.cycle,msg)
             WorkflowMgr.stderr(msg,1)
           else

--- a/lib/workflowmgr/workflowengine.rb
+++ b/lib/workflowmgr/workflowengine.rb
@@ -1919,16 +1919,17 @@ module WorkflowMgr
         uri=job.id
         jobid,output=@bqServer.get_submit_status(job.task,job.cycle)
         if output.nil?
-          @logServer.log(job.cycle,"Submission status of #{job.task} is pending at #{job.id}")
+          if WorkflowMgr::DRYRUN > 0
+            @dbServer.delete_jobs([job])
+            @logServer.log(job.cycle,"Submission of #{job.task} was a dryrun!")
+          else
+            @logServer.log(job.cycle,"Submission status of #{job.task} is pending at #{job.id}")
+          end
         else
           if jobid.nil?
             # Delete the job from the database since it failed to submit.  It will be retried next time around.
             @dbServer.delete_jobs([job])
-            if WorkflowMgr::DRYRUN > 0
-              msg="#{job.task} was not submitted!  #{output}"
-            else
-              msg="Submission of #{job.task} failed!  #{output}"
-            end
+            msg="Submission of #{job.task} failed!  #{output}"
             @logServer.log(job.cycle,msg)
             WorkflowMgr.stderr(msg,1)
           else

--- a/lib/workflowmgr/workflowoption.rb
+++ b/lib/workflowmgr/workflowoption.rb
@@ -17,6 +17,7 @@ module WorkflowMgr
     attr_reader :database
     attr_reader :workflowdoc
     attr_reader :verbose
+    attr_reader :dryrun
 
     ##########################################
     #
@@ -27,6 +28,7 @@ module WorkflowMgr
       @database=nil
       @workflowdoc=nil
       @verbose=1
+			@dryrun=0
       @more_args=parse(args)
 
     end  # initialize
@@ -72,6 +74,11 @@ module WorkflowMgr
           else
             @verbose=verbose.to_i
           end
+        end
+
+        # Handle option for dryrun
+        opts.on("-n","--dryrun","Show Workflow Manager commands, but do not execute") do |dryrun|
+          @dryrun=1
         end
 
         # Handle option for version
@@ -126,6 +133,9 @@ module WorkflowMgr
 
           # Set verbosity level
           WorkflowMgr.const_set("VERBOSE",@verbose)
+
+          # Set dryrun level
+          WorkflowMgr.const_set("DRYRUN",@dryrun)
 
           # Set workflow id
           WorkflowMgr.const_set("WORKFLOW_ID",File.basename(@workflowdoc))

--- a/lib/workflowmgr/workflowoption.rb
+++ b/lib/workflowmgr/workflowoption.rb
@@ -28,7 +28,7 @@ module WorkflowMgr
       @database=nil
       @workflowdoc=nil
       @verbose=1
-			@dryrun=0
+      @dryrun=0
       @more_args=parse(args)
 
     end  # initialize

--- a/lib/workflowmgr/workflowsubsetoptions.rb
+++ b/lib/workflowmgr/workflowsubsetoptions.rb
@@ -48,7 +48,7 @@ module WorkflowMgr
       super(opts)
 
       # Override the command usage text
-      opts.banner = "Usage:  #{@name} [-h] [-v #] -d database_file -w workflow_document [-c cycle_list] [-t task_list] [-m metatask_list] [-a]"
+      opts.banner = "Usage:  #{@name} [-h] [-v #] -d database_file -w workflow_document [-c cycle_list] [-t task_list] [-m metatask_list] [-a] [-n]"
 
       # Cycles of interest
       #      C   C,C,C  C:C  :C   C:


### PR DESCRIPTION
This PR:
- enables the user to provide an option `-n | --dryrun`  to `rocotorun`, `rocotoboot` commands.  When combined with `-v 10`, this option returns to `stdout` the jobcard that would have been submitted to the batch queuing system (BQS).
- ensures that the database is cleaned when `-n` is invoked, so that there is no record of the `dryrun` call
- ensures the logging is captured on the tasks that were invoked with `-n`.

Resolves #114 

A few sample outputs are included here as examples:

```
 ❯❯❯ rocotorun -n -v 10 -d ttt.db -w ttt.xml
06/05/25 09:11:01 EDT :: ttt.xml :: Submitting gfs_stage_ic using sbatch < /tmp/sbatch.in20250605-543006-11ti70d with input
{{
#! /bin/sh
#SBATCH --job-name=ttt_gfs_stage_ic_12
#SBATCH --account=da-cpu
#SBATCH --qos=batch
#SBATCH --partition=service
#SBATCH -t 00:15:00
#SBATCH --nodes=1-1
#SBATCH --tasks-per-node=1
#SBATCH --cpus-per-task=1
#SBATCH --mem=4096
#SBATCH -o /xxx/ttt/logs/2021032312/gfs_stage_ic.log
#SBATCH --export=NONE
#SBATCH --comment=043efe193d6aa501d63c92ba7b192cf6
export RUN_ENVIR='emc'
export HOMEgfs='/xxx/global-workflow'
export EXPDIR='/xxx/ttt'
export NET='gfs'
export RUN='gfs'
export CDATE='2021032312'
export PDY='20210323'
export cyc='12'
export COMROOT='/xxx/COMROOT'
export DATAROOT='/xxx/ttt/gfs.2021032312'
/xxx/global-workflow/dev/jobs/stage_ic.sh
}}
```

A peek in `logs/` after issuing the above call successively, reveals:
```
❯❯❯ cat logs/2021032312.log
2025-06-05 09:01:31 -0400 :: hfe09 :: Submitting gfs_stage_ic
2025-06-05 09:01:31 -0400 :: hfe09 :: Submission of gfs_stage_ic was a dryrun!
2025-06-05 09:02:06 -0400 :: hfe09 :: Submitting gfs_stage_ic
2025-06-05 09:02:06 -0400 :: hfe09 :: Submission of gfs_stage_ic was a dryrun!
2025-06-05 09:04:46 -0400 :: hfe09 :: Submitting gfs_stage_ic
2025-06-05 09:04:46 -0400 :: hfe09 :: Submission of gfs_stage_ic was a dryrun!
2025-06-05 09:07:14 -0400 :: hfe09 :: Submitting gfs_stage_ic
2025-06-05 09:07:14 -0400 :: hfe09 :: Submission of gfs_stage_ic was a dryrun!
2025-06-05 09:08:45 -0400 :: hfe09 :: Submitting gfs_stage_ic
2025-06-05 09:08:45 -0400 :: hfe09 :: Submission of gfs_stage_ic was a dryrun!
2025-06-05 09:11:01 -0400 :: hfe09 :: Submitting gfs_stage_ic
2025-06-05 09:11:01 -0400 :: hfe09 :: Submission of gfs_stage_ic was a dryrun!
```